### PR TITLE
Add http:// to the metric server URL

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -21,5 +21,5 @@ sles_repo_host: 'neptune.puppetlabs.lan'
 sles_arch_repos:
   i586: '/home/sles-iso/sles-11-sp1-i586:/home/sles-iso/sles-11-deps-i586'
   x86_64: '/home/sles-iso/sles-11-sp1-x86_64:/home/sles-iso/sles-11-deps-x86_64'
-metrics_url: 'metrics.delivery.puppetlabs.net:4567/overview/metrics'
+metrics_url: 'http://metrics.delivery.puppetlabs.net:4567/overview/metrics'
 benchmark: TRUE


### PR DESCRIPTION
Without this change, the Java HTTP library will not properly reach the server with its POST request.
