### PR TITLE
Add http:// to the metric server URL

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -15,5 +15,5 @@ jenkins_packaging_job: 'puppetlabs-packaging'
 jenkins_repo_path: '/opt/jenkins-builds'
 distribution_server: 'neptune.puppetlabs.lan'
 builds_server: 'builds.puppetlabs.lan'
-metrics_url: 'metrics.delivery.puppetlabs.net:4567/overview/metrics'
+metrics_url: 'http://metrics.delivery.puppetlabs.net:4567/overview/metrics'
 benchmark: TRUE


### PR DESCRIPTION
Without this change, the Java HTTP library will not properly reach the server with its POST request.
