### PR TITLE
Add default mocks and cows to pe-puppet-dashboard builder_data

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -1,2 +1,4 @@
 ---
 tarball_path: '/opt/pe_dev'
+final_mocks: 'pupent-3.4-el4-i386 pupent-3.4-el4-x86_64 pupent-3.4-el5-i386 pupent-3.4-el5-x86_64 pupent-3.4-el6-i386 pupent-3.4-el6-x86_64 pupent-3.4-el7-x86_64 pupent-3.4-eos4-i386 pupent-3.4-eos4-x86_64 pupent-3.4-sles10-i386 pupent-3.4-sles10-x86_64 pupent-3.4-sles11-i386 pupent-3.4-sles11-x86_64'
+cows: 'base-cumulus1.5-powerpc.cow base-lucid-i386.cow base-lucid-amd64.cow base-precise-i386.cow base-precise-amd64.cow base-squeeze-i386.cow base-squeeze-amd64.cow base-trusty-i386.cow base-trusty-amd64.cow base-wheezy-i386.cow base-wheezy-amd64.cow'


### PR DESCRIPTION
Adding these here will override entries in the project metadata and allow us to set up a set of default PE build platforms. These entries override the entries in the team-specific branch.
