### PR TITLE
 Add default mocks and cows to higgs builder_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-build-data
-==========
-
-source of additional information pertaining to build automation

--- a/builder_data.yml
+++ b/builder_data.yml
@@ -1,0 +1,3 @@
+---
+final_mocks: 'pupent-3.4-el4-i386 pupent-3.4-el4-x86_64 pupent-3.4-el5-i386 pupent-3.4-el5-x86_64 pupent-3.4-el6-i386 pupent-3.4-el6-x86_64 pupent-3.4-el7-x86_64 pupent-3.4-eos4-i386 pupent-3.4-eos4-x86_64 pupent-3.4-sles10-i386 pupent-3.4-sles10-x86_64 pupent-3.4-sles11-i386 pupent-3.4-sles11-x86_64'
+cows: 'base-cumulus1.5-powerpc.cow base-lucid-i386.cow base-lucid-amd64.cow base-precise-i386.cow base-precise-amd64.cow base-squeeze-i386.cow base-squeeze-amd64.cow base-trusty-i386.cow base-trusty-amd64.cow base-wheezy-i386.cow base-wheezy-amd64.cow'


### PR DESCRIPTION
Adding these here will override entries in the project metadata and allow us to set up a set of default PE build platforms. These entries override the entries in the team-specific branch.
