### PR TITLE
Add default mocks and cows to pe-release team builder_data

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -17,3 +17,5 @@ jenkins_packaging_job: 'puppetlabs-packaging'
 builds_server: 'builds.puppetlabs.lan'
 metrics_url: 'http://metrics.delivery.puppetlabs.net/overview/metrics'
 benchmark: TRUE
+final_mocks: 'pupent-3.4-el4-i386 pupent-3.4-el5-i386 pupent-3.4-el6-i386 pupent-3.4-el7-x86_64 pupent-3.4-eos4-i386 pupent-3.4-sles10-i386 pupent-3.4-sles11-i386'
+cows: 'base-cumulus1.5-powerpc.cow base-lucid-i386.cow base-precise-i386.cow base-squeeze-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'


### PR DESCRIPTION
Adding these here will override entries in the project metadata and allow us to set up a set of default PE build platforms. These can be overridden in the project-specific branches.
