### PR TITLE
(CPR-8) Add gem_path and gem_host to build data

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -1,2 +1,4 @@
 ---
 tarball_path: '/opt/downloads/facter'
+gem_path: '/opt/downloads/facter'
+gem_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
This commit puts gem_host and gem_path into the branch specific
build_data. This allows for us to send our gems to the correct
locations.
