### PR TITLE
(maint) Add OSX info to the builder_data

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -19,3 +19,6 @@ yum_repo_command: |
     sudo createrepo --checksum=sha --database --update "${repodir}";
     echo "Finished generating repodata for ${repodir}..."
   done;
+osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
+osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
+osx_signing_server: 'osx-signer.delivery.puppetlabs.net'


### PR DESCRIPTION
We were missing the signing cert, keychain, and server for OSX in the
pl-build-tools branch, so this copied the information over from the
puppet-agent branch.
