### PR TITLE
(MAINT) Fix bad path for apt_repo_path

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -19,7 +19,7 @@ builds_server: builds.puppetlabs.lan
 metrics_url: http://metrics.delivery.puppetlabs.net/overview/metrics
 benchmark: true
 apt_signing_server: weth.delivery.puppetlabs.net
-apt_repo_path: "/opt/dummy-repository/apt"
+apt_repo_path: "/opt/repository/apt"
 apt_repo_staging_path: "/opt/tools/freight/apt"
 yum_repo_path: "/opt/repository/yum"
 apt_repo_command: |


### PR DESCRIPTION
I left a testing path in, and that's my fault. Sorry.
