### PR TITLE
(maint) Add gem info for razor-client build data

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -1,2 +1,4 @@
 ---
 tarball_path: '/opt/downloads/razor-client'
+gem_path: '/opt/downloads/razor-client'
+gem_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
razor-client ships a gem, so it needs to set the gem_path and
gem_host.
