### PR TITLE
(maint) Set `gpg_key` for the release user

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -1,5 +1,6 @@
 ---
 team: release
+gpg_key: '4BD6EC30'
 rpm_build_host: rpm-builder.delivery.puppetlabs.net
 deb_build_host: builder-deb.delivery.puppetlabs.net
 osx_build_host: osx-builder.delivery.puppetlabs.net


### PR DESCRIPTION
With our attempt to ensure we're signing all packages with the same key,
we should set the gpg_key here. This ensures we use the same key for all
projects. If a projects forgets to set `gpg_key`, then we can still
successfully sign packages. If a projects wants to use a different key,
then they can set it in the project-specific build-data file.
