### PR TITLE
(maint) Remove EOL plaforms

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -74,8 +74,6 @@ foss_platforms:
   - el-6-x86_64
   - el-7-x86_64
   - eos-4-i386
-  - fedora-f22-i386
-  - fedora-f22-x86_64
   - fedora-f23-i386
   - fedora-f23-x86_64
   - fedora-f24-i386
@@ -83,7 +81,6 @@ foss_platforms:
   - fedora-f25-i386
   - fedora-f25-x86_64
   - huaweios-6-powerpc
-  - osx-10.9-x86_64
   - osx-10.10-x86_64
   - osx-10.11-x86_64
   - osx-10.12-x86_64
@@ -94,8 +91,6 @@ foss_platforms:
   - ubuntu-12.04-i386
   - ubuntu-14.04-amd64
   - ubuntu-14.04-i386
-  - ubuntu-15.10-amd64
-  - ubuntu-15.10-i386
   - ubuntu-16.04-amd64
   - ubuntu-16.04-i386
   - windows-2012-x86


### PR DESCRIPTION
This commit removes fedora 22, osx 10.9, and ubuntu 15.10, since these platforms are EOL (see PA-896).