### PR TITLE
(CPR-407) Enable packaging to ship fedora packages to repos not prepended with f

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -80,6 +80,10 @@ foss_platforms:
   - fedora-f24-x86_64
   - fedora-f25-i386
   - fedora-f25-x86_64
+  - fedora-24-i386
+  - fedora-24-x86_64
+  - fedora-25-i386
+  - fedora-25-x86_64
   - huaweios-6-powerpc
   - osx-10.10-x86_64
   - osx-10.11-x86_64


### PR DESCRIPTION
This commit removes the f before the version number for fedora platforms.