### PR TITLE
(maint) Add Power8 Ubuntu and RHEL to foss_platforms

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -73,6 +73,7 @@ foss_platforms:
   - el-6-i386
   - el-6-x86_64
   - el-7-x86_64
+  - el-7-ppc64le
   - eos-4-i386
   - fedora-f24-i386
   - fedora-f24-x86_64
@@ -89,6 +90,7 @@ foss_platforms:
   - ubuntu-14.04-i386
   - ubuntu-16.04-amd64
   - ubuntu-16.04-i386
+  - ubuntu-16.04-ppc64el
   - ubuntu-16.10-amd64
   - ubuntu-16.10-i386
   - windows-2012-x86


### PR DESCRIPTION
Note: my understanding is that this is necessary to enable builds to automatically be shipped to nightlies.puppetlabs.com. My intention is not to add these platforms to our official puppet-agent releases just yet.