### PR TITLE
Add rsync servers to builder_data.yaml

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -96,3 +96,6 @@ foss_platforms:
   - ubuntu-16.10-i386
   - windows-2012-x86
   - windows-2012-x64
+rsync_servers:
+  - 'downloadserver-rsync-prod-1.ops.puppetlabs.net'
+  - 'downloadserver-rsync-prod-2.ops.puppetlabs.net'


### PR DESCRIPTION
We need to list rsync servers as defaults here so that the packaging rake task can ship to the rsync servers.