### PR TITLE
(RE-9306) update_yum_repo makes you type the passphrase a million times

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -49,6 +49,9 @@ apt_repo_command: |
   fi
   keychain -k mine;
 yum_repo_command: |
+  keychain -k mine;
+  eval $(/usr/bin/keychain -q --agents gpg --eval __GPG_KEY__);
+  export GPG_TTY=$(tty);
   for repodir in $(find "__REPO_PATH__" -mindepth 2 -name "*.rpm" | xargs -I {} dirname {} | uniq) ; do
     [ -d "${repodir}" ] || continue ;
     echo "Generating and signing repodata for ${repodir} with __GPG_KEY__..." ;
@@ -59,6 +62,7 @@ yum_repo_command: |
     sudo chown -R root:release "${repodir}/repodata" ;
     sudo chmod -R g+w "${repodir}/repodata"
   done;
+  keychain -k mine;
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'


### PR DESCRIPTION
This commit adds steps to the yum_repo_command to use keychain to set up a gpg agent. This is what the apt_repo_command does, which did not have the problem of having to type your passphrase over and over.