### PR TITLE
(maint) Make lock for nonfinal_apt_repo_command distinct from lock for apt_repo_command

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -61,7 +61,7 @@ apt_repo_command: |
   ) 200>/var/lock/apt-repo-lock
 nonfinal_apt_repo_command: |
   (
-    flock --wait 600 200
+    flock --wait 600 400
     keychain -k mine;
     eval $(/usr/bin/keychain -q --agents gpg --eval __GPG_KEY__);
     export GPG_TTY=$(tty);
@@ -73,7 +73,7 @@ nonfinal_apt_repo_command: |
       done
     fi
     keychain -k mine;
-  ) 200>/var/lock/apt-repo-lock
+  ) 400>/var/lock/apt-nightly-repo-lock
 yum_repo_command: |
   (
     flock --wait 600 300


### PR DESCRIPTION
This commit changes the lock name and file descriptor for the nonfinal_apt_repo_command to be different from those for the regular apt_repo_command. We have recently run into lock issues when simultaneously running final and nonfinal repo updates. This should fix that.