### PR TITLE
(RE-9325) Optimize yum repo updates

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -79,7 +79,7 @@ yum_repo_command: |
     flock --wait 600 300
     keychain -k mine;
     eval $(/usr/bin/keychain -q --agents gpg --eval __GPG_KEY__);
-    for repodir in $(find "__REPO_PATH__" -mindepth 3 -name "*.rpm" | xargs -I {} dirname {} | sort | uniq) ; do
+    for repodir in $(find "__REPO_PATH__" -mindepth 3 -path "*__REPO_NAME__*.rpm" | xargs -I {} dirname {} | sort | uniq) ; do
       [ -d "${repodir}" ] || continue ;
       echo "Generating and signing repodata for ${repodir} with __GPG_KEY__..." ;
       if [ -d "${repodir}/repodata" ]; then


### PR DESCRIPTION
This commit changes the yum_repo_command to look for paths that include the
specified repo name. Previously, we were just looking for any directories that
contained rpms, which resulted in updating every single yum repo every time we
shipped, which took forever.