### PR TITLE
(RE-10432) Add gem_host and gem_path for shipping cfacter

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -3,3 +3,5 @@ osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'jenkins@osx-signer.delivery.puppetlabs.net'
 ips_signing_server: 'rama.delivery.puppetlabs.net'
+gem_host: 'weth.delivery.puppetlabs.net'
+gem_path: '/opt/downloads/facter'


### PR DESCRIPTION
This commit adds the gem_host and gem_path parameters for puppet-agent. Since
cfacter is built and shipped as part of the puppet-agent project, these values
must be set for puppet-agent.