### PR TITLE
(maint) Set `yum_host` and `apt_host` to saturn

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -24,8 +24,8 @@ metrics_url: http://metrics.delivery.puppetlabs.net/overview/metrics
 benchmark: false
 staging_server: weth.delivery.puppetlabs.net
 signing_server: mozart.delivery.puppetlabs.net
-yum_host: 'yum.puppetlabs.com'
-apt_host: 'apt.puppetlabs.com'
+yum_host: 'enterprise.delivery.puppetlabs.net'
+apt_host: 'enterprise.delivery.puppetlabs.net'
 tar_host: 'downloads.puppetlabs.com'
 msi_host: 'downloads.puppetlabs.com'
 dmg_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
This commit updates the `yum_host` and `apt_host` params to
'saturn.delivery.puppetlabs.net'. These were set to 'yum.puppetlabs.com' and
'apt.puppetlabs.com' from before we switched to using s3 for public downloads.
Currently, these parameters appear to only be in use when shipping for PE (i.e.
promoting).

As we work to move signing up in our build process, we need to set TEAM=release
in our build jobs to ensure that this branch of build-data gets fetched and
that all necessary packaging parameters are set. Previously, when attempting to
promote a build for a project where `build_pe: true` is not set, the `apt_host`
and `yum_host` commands were set incorrectly, since the 'release' branch of
this repo gets fetched, rather than the 'pe-release' branch. Since some repos
contain both PE projects and foss-only projects together (e.g. bolt-vanagon),
we decided that adding the `build_pe: true` setting could be potentially
dangerous and confusing, so we've opted for this solution instead.