### PR TITLE
(maint) Add ips_signing_ssh_key

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -97,6 +97,7 @@ osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'jenkins@osx-signer.delivery.puppetlabs.net'
 msi_signing_server: 'windowssigning-aio1-prod.delivery.puppetlabs.net'
+ips_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 internal_nexus_host: 'http://nexus.delivery.puppetlabs.net:8081/content/repositories/gems-internal'
 s3_ship: true
 foss_platforms:


### PR DESCRIPTION
This commit adds and sets the `ips_signing_ssh_key` param. This is used when
sshing into our solaris signer. Currently, this param is set as an environment
variable in several jenkins jobs. Adding it here will improve maintainability,
since we won't have to add this param to every job that does solaris signing.