### PR TITLE
(maint) Add osx_signing_ssh_key and msi_signing_ssh_key

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -96,7 +96,9 @@ yum_repo_command: |
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'jenkins@osx-signer.delivery.puppetlabs.net'
+osx_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 msi_signing_server: 'windowssigning-aio1-prod.delivery.puppetlabs.net'
+msi_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 ips_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 internal_nexus_host: 'http://nexus.delivery.puppetlabs.net:8081/content/repositories/gems-internal'
 s3_ship: true


### PR DESCRIPTION
This commit adds and sets the `osx_signing_ssh_key` and `msi_signing_ssh_key`
params. These are used when sshing into our osx and msi signers. Currently,
these params are set as environment variables in several jenkins jobs. Adding
them here will improve maintainability, since we won't have to add these params
to every job that does signing.