### PR TITLE
(maint) Increase yum repo update wait time to 20 minutes

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -76,7 +76,7 @@ nonfinal_apt_repo_command: |
   ) 400>/var/lock/apt-nightly-repo-lock
 yum_repo_command: |
   (
-    flock --wait 600 300
+    flock --wait 1200 300
     keychain -k mine;
     eval $(/usr/bin/keychain -q --agents gpg --eval __GPG_KEY__);
     for repodir in $(find "__REPO_PATH__" -mindepth 3 -path "*__REPO_NAME__*.rpm" | xargs -I {} dirname {} | sort | uniq) ; do


### PR DESCRIPTION
This commit increases the flock wait time for yum repo updates from 10 minutes
to 20 minutes (1200 seconds). This is intended to avoid unnecessary timeouts if
multiple repo update jobs are run at the same time, which may happen more as we
add separate repo update jobs for different projects.