### PR TITLE
(PA-3134) Add Ubuntu 20.04

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -148,6 +148,7 @@ foss_platforms:
   - ubuntu-16.04-i386
   - ubuntu-16.04-ppc64el
   - ubuntu-18.04-amd64
+  - ubuntu-20.04-amd64
   - windows-2012-x86
   - windows-2012-x64
 rsync_servers:


### PR DESCRIPTION
puppet-agent builds on Ubuntu20.04 are available