### PR TITLE
Revert "(RE-13743) Add new freight calls for puppet7 pathing"

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -37,6 +37,10 @@ dmg_staging_server: 'weth.delivery.puppetlabs.net'
 swix_staging_server: 'weth.delivery.puppetlabs.net'
 msi_staging_server: 'weth.delivery.puppetlabs.net'
 apt_signing_server: weth.delivery.puppetlabs.net
+apt_repo_path: "/opt/repository/apt"
+apt_repo_staging_path: "/opt/tools/freight/apt"
+nonfinal_apt_repo_path: "/opt/repository-nightlies/apt"
+nonfinal_apt_repo_staging_path: "/opt/tools/freight-nightlies/apt"
 yum_staging_server: weth.delivery.puppetlabs.net
 yum_repo_path: "/opt/repository/yum"
 nonfinal_yum_repo_path: "/opt/repository-nightlies/yum"
@@ -44,100 +48,6 @@ apt_archive_path: "/opt/release-archives-staging/apt"
 freight_archive_path: "/opt/tools/freight-archives/apt"
 yum_archive_path: "/opt/release-archives-staging/yum"
 downloads_archive_path: "/opt/release-archives-staging/downloads"
-
-# Prior to puppet7, apt repos contained all the puppet versions:
-#
-#  /opt/tools/freight/apt/<distro>/<puppet_version>
-#
-# For example:
-#  /opt/tools/freight/apt/bionic/puppet
-#  /opt/tools/freight/apt/bionic/puppet5
-#  /opt/tools/freight/apt/bionic/puppet6
-#
-# Starting with puppet7, we stage apt repos for each puppet major version:
-#  /opt/tools/<puppet-version>/{freight,freight-nighlies}/apt/<distro>
-#
-# Example:
-#  /opt/tools/puppet7/freight/apt/bionic
-# 
-# Freight then builds the repositories and deploys them to:
-#  /opt/repository/apt/puppet7
-#
-# Each major puppet release (puppet7, puppet8, puppet9, ...) requires a dedicated freight
-# configuration to manage the VARLIB and VARCACHE locations.
-
-puppet7_apt_repo_path: "/opt/repository/apt/puppet7"
-puppet7_apt_repo_staging_path: "/opt/tools/puppet7/freight/apt"
-puppet7_nonfinal_apt_repo_path: "/opt/repository-nightlies/apt/puppet7"
-puppet7_nonfinal_apt_repo_staging_path: "/opt/tools/puppet7/freight-nightlies/apt"
-
-puppet7_stable_apt_repo_generate: |
-  (
-    flock --wait 600 270
-    keychain -k mine;
-    eval $(/usr/bin/keychain -q --agents gpg --eval __GPG_KEY__);
-    export GPG_TTY=$(tty);
-    freight_configuration=/etc/freight.conf.d/puppet7_stable.conf;
-    if printf -- %s "__APT_DISTROS__" | grep --quiet -- APT_DISTROS; then
-      sudo --preserve-env freight cache --conf=$freight_configuration &
-    else
-      for apt_distro in __APT_DISTROS__; do
-        sudo --preserve-env freight cache --conf=$freight_configuration apt/$apt_distro &
-      done
-    fi
-    wait
-    keychain -k mine;
-  ) 270>/var/lock/puppet7_stable_apt_repo_generate.lock
-
-puppet7_nonfinal_apt_repo_generate: |
-  (
-    flock --wait 600 470
-    keychain -k mine;
-    eval $(/usr/bin/keychain -q --agents gpg --eval __GPG_KEY__);
-    export GPG_TTY=$(tty);
-    freight_configuration=/etc/freight-nightly.conf.d/puppet7_nonfinal.conf;
-    if printf -- %s "__APT_DISTROS__" | grep --quiet -- APT_DISTROS; then
-      sudo --preserve-env freight cache --conf=$freight_configuration &
-    else
-      for apt_distro in __APT_DISTROS__; do
-        sudo --preserve-env freight cache --conf=$freight_configuration apt/$apt_distro &
-      done
-    fi
-    wait
-    keychain -k mine;
-  ) 470>/var/lock/puppet7_nonfinal_apt_repo_generate.lock
-
-## Likely not used
-puppet7_archive_apt_repo_generate: |
-  (
-    flock --wait 600 670
-    keychain -k mine;
-    eval $(/usr/bin/keychain -q --agents gpg --eval __GPG_KEY__);
-    export GPG_TTY=$(tty);
-    freight_configuration=/etc/freight.conf.d/puppet7_archive.conf;
-    if printf -- %s "__APT_DISTROS__" | grep --quiet -- APT_DISTROS; then
-      sudo --preserve-env freight cache --conf=$freight_configuration &
-    else
-      for apt_distro in __APT_DISTROS__; do
-        sudo --preserve-env freight cache --conf=$freight_configuration apt/$apt_distro &
-      done
-    fi
-    wait
-    keychain -k mine;
-  ) 670>/var/lock/puppet7_archive_apt_repo_generate.lock
-
-
-# Prior to puppet7, apt repos were organized by debian codenames inside of
-# /opt/tools/freight/apt, /opt/tools/freight-nightlies/apt,
-# Examples:
-#   /opt/tools/freight/apt/xenial
-#   /opt/tools/freight-nightlies/apt/bionic
-#
-# These handle that condition
-apt_repo_path: "/opt/repository/apt"
-apt_repo_staging_path: "/opt/tools/freight/apt"
-nonfinal_apt_repo_path: "/opt/repository-nightlies/apt"
-nonfinal_apt_repo_staging_path: "/opt/tools/freight-nightlies/apt"
 apt_repo_command: |
   (
     flock --wait 600 200
@@ -154,7 +64,6 @@ apt_repo_command: |
     wait
     keychain -k mine;
   ) 200>/var/lock/apt-repo-lock
-
 nonfinal_apt_repo_command: |
   (
     flock --wait 600 400
@@ -171,7 +80,6 @@ nonfinal_apt_repo_command: |
     wait
     keychain -k mine;
   ) 400>/var/lock/apt-nightly-repo-lock
-
 apt_archive_repo_command: |
   (
     flock --wait 600 600
@@ -188,7 +96,6 @@ apt_archive_repo_command: |
     wait
     keychain -k mine;
   ) 600>/var/lock/apt-archive-repo-lock
-
 yum_repo_command: |
   (
     flock --wait 1200 300


### PR DESCRIPTION
This reverts commit 709734e130af22f9c248d6709c9cd21ca206186b.

This earlier attempt at doing new apt pathing didn't quite work
out. Revert the abandoned work and we'll try another swing at it soon.