### PR TITLE
(PA-3619) Update builder_data.yaml to enable OSX 11 Big Sur for public nightlies ship

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -150,6 +150,7 @@ foss_platforms:
   - fedora-32-x86_64
   - osx-10.14-x86_64
   - osx-10.15-x86_64
+  - osx-11-x86_64
   - sles-11-i386
   - sles-11-x86_64
   - sles-12-x86_64


### PR DESCRIPTION
To be merged after the current puppet_agent releases. 