### PR TITLE
(maint) move signing server to 'composer-deb-prod-1'

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -23,7 +23,7 @@ builds_server: builds.delivery.puppetlabs.net
 metrics_url: http://metrics.delivery.puppetlabs.net/overview/metrics
 benchmark: false
 staging_server: weth.delivery.puppetlabs.net
-signing_server: mozart.delivery.puppetlabs.net
+signing_server: composer-deb-prod-1.delivery.puppetlabs.net
 yum_host: 'enterprise.delivery.puppetlabs.net'
 apt_host: 'enterprise.delivery.puppetlabs.net'
 tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
mozart is being decommissioned. Update signing server to 'composer-deb-prod-1'