### PR TITLE
(PA-3912) Add osx-11-arm64 to build data

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -150,6 +150,7 @@ foss_platforms:
   - fedora-34-x86_64
   - osx-10.14-x86_64
   - osx-10.15-x86_64
+  - osx-11-arm64
   - osx-11-x86_64
   - sles-11-i386
   - sles-11-x86_64


### PR DESCRIPTION
If everything works out we should only be shipping nightly packages, not release packages.