### PR TITLE
Revert "Revert "Merge pull request #188 from GabrielNagy/PA-3877/ubuntu-18-aa…"

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -163,6 +163,7 @@ foss_platforms:
   - ubuntu-16.04-i386
   - ubuntu-16.04-ppc64el
   - ubuntu-18.04-amd64
+  - ubuntu-18.04-aarch64
   - ubuntu-20.04-amd64
   - ubuntu-20.04-aarch64
   - windows-2012-x86


### PR DESCRIPTION
Reverts puppetlabs/build-data#189

Since the release is publicly available, we could revert this and add ubuntu-18.04-aarch64 platform back