### PR TITLE
(RE-13380) Update osx signer to osx-signer-prod-2 

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -121,7 +121,7 @@ yum_repo_command: |
   ) 300>/var/lock/yum-repo-lock
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
-osx_signing_server: 'jenkins@osx-signer.delivery.puppetlabs.net'
+osx_signing_server: 'jenkins@osx-signer-prod-2.delivery.puppetlabs.net'
 osx_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 msi_signing_server: 'windowssigning-aio1-prod.delivery.puppetlabs.net'
 msi_signing_ssh_key: '/home/jenkins/.ssh/id_signing'


### PR DESCRIPTION
Update the signing server to support Apple Notarization. 