### PR TITLE
(maint) Remove osx_signing_server entry

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -1,7 +1,3 @@
 ---
 gem_host: 'weth.delivery.puppetlabs.net'
 gem_path: '/opt/downloads/facter'
-
-## RE-14577 hackery to get pipelines green
-osx_signing_server: 'jenkins@osx-signer-prod-2.delivery.puppetlabs.net'
-


### PR DESCRIPTION
This way it will pick up 'osx_signing_server' from the release branch.