### PR TITLE
(PA-4466) Add macOS 12 M1 to build data

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -149,6 +149,7 @@ foss_platforms:
   - osx-10.15-x86_64
   - osx-11-arm64
   - osx-11-x86_64
+  - osx-12-arm64
   - osx-12-x86_64
   - sles-11-i386
   - sles-11-x86_64


### PR DESCRIPTION
Adds support for macOS 12 Monterey M1/ARM64