### PR TITLE
(Revert "(RE-13980) Change signing_server from back to composer-deb-prod-2 again."

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -23,7 +23,7 @@ builds_server: builds.delivery.puppetlabs.net
 metrics_url: http://metrics.delivery.puppetlabs.net/overview/metrics
 benchmark: false
 staging_server: weth.delivery.puppetlabs.net
-signing_server: composer-deb-prod-2.delivery.puppetlabs.net
+signing_server: mozart.delivery.puppetlabs.net
 yum_host: 'enterprise.delivery.puppetlabs.net'
 apt_host: 'enterprise.delivery.puppetlabs.net'
 tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
This reverts commit f1a099065f1704a93d62d49463d1a82cae4d1b14.

grumble, composer-deb-prod-2 has a gpg agent that keeps dying for yet-to-be-discovered reasons.

Bring mozart back for the time.