### PR TITLE
(PA-4597) Enable macOS 13 (Intel) for public nightlies ship

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -150,6 +150,7 @@ foss_platforms:
   - osx-11-x86_64
   - osx-12-arm64
   - osx-12-x86_64
+  - osx-13-x86_64
   - osx-13-arm64
   - sles-12-x86_64
   - sles-12-ppc64le


### PR DESCRIPTION
enabled for macos13 intel for public nightlies ship