### PR TITLE
(PA-6279) Update builder_data.yaml with AL2 for public nightlies ship

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -141,6 +141,7 @@ s3_ship: true
 foss_platforms:
   - amazon-2023-x86_64
   - amazon-2023-aarch64
+  - amazon-7-aarch64
   - debian-10-amd64
   - debian-11-amd64
   - debian-11-aarch64


### PR DESCRIPTION
Added Amazon Linux 2 as a FOSS platform release in builder_data.yaml file