### PR TITLE
Rename Amazon 7 to 2

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -141,7 +141,7 @@ s3_ship: true
 foss_platforms:
   - amazon-2023-x86_64
   - amazon-2023-aarch64
-  - amazon-7-aarch64
+  - amazon-2-aarch64
   - debian-10-amd64
   - debian-11-amd64
   - debian-11-aarch64


### PR DESCRIPTION
Amazon 7 is an implementation detail, the actual OS is named Amazon 2