### PR TITLE
(maint) Pick up some obsolete stragglers

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -122,8 +122,6 @@ osx_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 msi_signing_server: 'jenkins@msi-signer-prod-1.delivery.puppetlabs.net'
 msi_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 
-gcp_signed_bucket: 'windows-signed-bucket-prod'
-gcp_tosign_bucket: 'windows-tosign-bucket-prod'
 s3_ship: true
 foss_platforms:
   - amazon-2023-x86_64


### PR DESCRIPTION
gcp_*_bucket were used in the gcp-based msi signing method that we stopped using