### PR TITLE
(RE-16623) Update osx signer information

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -115,8 +115,8 @@ yum_repo_command: |
     keychain -k mine;
   ) 300>/var/lock/yum-repo-lock
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
-osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
-osx_signing_server: 'jenkins@osx-signer-prod-2.delivery.puppetlabs.net'
+osx_signing_keychain: "Puppet Labs VKGLGN2B6Y"
+osx_signing_server: 'jenkins@osx-signer-prod-3.delivery.puppetlabs.net'
 osx_signing_ssh_key: '/home/jenkins/.ssh/id_signing'
 
 msi_signing_server: 'jenkins@msi-signer-prod-1.delivery.puppetlabs.net'


### PR DESCRIPTION
We created a new signing server, osx-signer-prod-3, after prod-2 spectacularly crashed.

In reinstating the signing scripts, made the keychain name more specific.