### PR TITLE
(PA-6780): Update builder_data.yaml to enable MacOS 15 Intel(x86_64) for nightlies ship

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -153,6 +153,7 @@ foss_platforms:
   - osx-13-arm64
   - osx-14-x86_64
   - osx-14-arm64
+  - osx-15-x86_64
   - osx-15-arm64
   - sles-12-x86_64
   - sles-12-ppc64le


### PR DESCRIPTION
Update builder_data.yaml to enable MacOS 15 Intel for nightlies ship