### PR TITLE
(PA-8304): Add osx-26-x86_64 to foss_platforms in builder_data.yaml

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -159,6 +159,7 @@ foss_platforms:
   - osx-14-arm64
   - osx-15-x86_64
   - osx-15-arm64
+  - osx-26-x86_64
   - osx-26-arm64
   - sles-12-x86_64
   - sles-12-ppc64le


### PR DESCRIPTION
Add `osx-26-x86_64` to foss_platforms in builder_data.yaml



Note: Due to a bug (PR [puppet-private #130](https://github.com/puppetlabs/puppet-private/pull/130)) affecting macOS 26 on Intel, we do not want to proceed with Puppet 9 nightly releases for this platform. However, Puppet 8.x is good to go for macOS 26 Intel.