### PR TITLE
(PA-8269) Update builder_data.yaml to enable ubuntu-26.04-aarch64 for nightlies ship

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -172,6 +172,7 @@ foss_platforms:
   - ubuntu-22.04-aarch64
   - ubuntu-24.04-amd64
   - ubuntu-24.04-aarch64
+  - ubuntu-26.04-aarch64
   - windows-2012-x86
   - windows-2012-x64
 gpg_legacy_hosts:


### PR DESCRIPTION
## Summary

Add \`ubuntu-26.04-aarch64\` to \`foss_platforms\` in \`builder_data.yaml\`, adjacent to its same-family sibling \`ubuntu-24.04-aarch64\`. Enables nightly publish of puppet-agent packages for the new platform.

## Validation

\`\`\`bash
ruby -ryaml -e 'YAML.load_file("builder_data.yaml")'  # exits 0
\`\`\`

## Reference PR

- build-data@a662593 (PA-6754 — \`osx-15-arm64\`) — same single-line addition shape.
- Most recent same-family analogue: [PA-7975](https://github.com/puppetlabs/build-data/pull/263) — \`debian-13-amd64\`.

## Pre-merge requirement

> RelEng must confirm in PA-8269 that this platform should be in the next scheduled release before merging.

## Test plan
- [ ] RelEng confirmation recorded on PA-8269.
- [ ] After merge, confirm next FOSS nightly ships ubuntu-26.04-aarch64 packages to the public release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)