### PR TITLE
(PA-8462) Enable ubuntu-26.04-amd64 for FOSS ship in builder_data.yaml

### DIFF
--- a/builder_data.yaml
+++ b/builder_data.yaml
@@ -172,6 +172,7 @@ foss_platforms:
   - ubuntu-22.04-aarch64
   - ubuntu-24.04-amd64
   - ubuntu-24.04-aarch64
+  - ubuntu-26.04-amd64
   - ubuntu-26.04-aarch64
   - windows-2012-x86
   - windows-2012-x64


### PR DESCRIPTION
## Summary
Adds `ubuntu-26.04-amd64` to the `foss_platforms` list in `builder_data.yaml` (release branch). `ubuntu-26.04-aarch64` is already present; this adds the amd64 sibling.

## Why
Step 10 of [How to add a platform for puppet-agent](https://perforce.atlassian.net/wiki/spaces/AGENT/pages/369365152/How+to+add+a+platform+for+puppet-agent). Enabling the platform here makes it eligible for FOSS ship and includes it in the next puppet-agent release.

## ⚠️ Merge precondition — RelEng confirmation required
Per the runbook: *"Enabling the platform here also enables shipping the platform during the next puppet-agent release, so if the intention is not for this platform to be included in the next agent release, discuss with RelEng before working on this ticket."*

**Do not merge until RelEng confirms `ubuntu-26.04-amd64` is intended for the next puppet-agent release.** Kept as draft for that reason.

## Validation
- Single-line addition; `YAML.safe_load_file(..., aliases: true)` parses cleanly.

## Acceptance (PA-8462)
`build-data/blob/release/builder_data.yaml` includes Ubuntu-26.04 AMD.

## Jira
[PA-8462](https://perforce.atlassian.net/browse/PA-8462) — epic PA-8278

🤖 Generated with [Claude Code](https://claude.com/claude-code)